### PR TITLE
fix loading words on compare page

### DIFF
--- a/keyboard_compare.js
+++ b/keyboard_compare.js
@@ -48,7 +48,7 @@ var stats = d3.select("#svgstats").append("svg").attr("width", swidth).attr("hei
 // const el = document.querySelector("#svgstats");
 // el.onwheel = scroll;
 
-const word_list_url = 'word_list.json';
+const word_list_url = 'words-english.json';
 const dictionary_url = 'dictionary.json';
 const effort_url = 'bigram_effort.json';
 let words = {};


### PR DESCRIPTION
I'm getting a 404 on the compare keyboards page due to a recent change to the words filenames. I've fixed it for english, but I don't see where or how it should work for other languages (no button to switch languages on this page?)

<img width="440" height="62" alt="image" src="https://github.com/user-attachments/assets/2d3444e7-4c28-4e30-97a8-80c3240ec014" />
<img width="516" height="46" alt="image" src="https://github.com/user-attachments/assets/a892a52d-0539-4bb1-99ea-63fdea899618" />
