### PR TITLE
Some performance improvements + failed attempt to Map keys in O(1)

### DIFF
--- a/keyboard_svg.js
+++ b/keyboard_svg.js
@@ -6,8 +6,8 @@ var url_layout = params.layout;
 
 var swidth = 1000;
 var sheight = 180;
-
-var w = 38;
+var w = 38; // seems to be const?
+const inv_w = 1.0 / 38
 var gap = 8;
 var letter = "";
 var x = 0;
@@ -219,6 +219,26 @@ var rcdata = [
   ["back", 3, 6, 0, 0, 0, 1, 38],
   ["space", 3, 7, 0, 0, 0, 1, 39],
 ]
+const rcdata_len = rcdata.length // Compute once
+
+const column_map = {}; // Fast column lookup
+for (let i = 0; i < rcdata_len; i++) {
+  column_map[rcdata[i][0]] = rcdata[i][2];
+}
+const getCol = letter => column_map[letter] ?? -1;
+
+const row_map = {}; // Fast row lookup
+for (let i = 0; i < rcdata_len; i++) {
+  row_map[rcdata[i][0]] = rcdata[i][1];
+}
+const getRow = letter => row_map[letter] ?? -1;
+
+const char_map = {}; // Fast char lookup
+for (let i = 0; i < rcdata_len; i++) {
+  // (row * w + col) is unique per character
+  char_map[row * w + column] = rcdata[i][0];
+}
+const getChar = (row,col) => char_map[row * w + column] ?? "!";
 
 var effort = [
   [
@@ -500,12 +520,8 @@ function pasteEffortGridFromClipboard() {
 }
 
 function getEffort(row, column){
-  if (effort[row]){
-    if (effort[row][column]){
-      return effort[row][column];
-    }
-  }
-  return 0;
+  if (row == -1 || column == -1) { return 0; }
+  return effort[row][column];
 }
 
 var skip_toggle = false;
@@ -833,19 +849,22 @@ function importLayout(layout) {
 
 function exportLayout() {
   var str = "";
-  for (let i = 0; i <= 33; i++) {
-    if (rcdata[i][0] == "space" && i == 33){
-      str += rcdata[39][0];
-      thumb = "r"
-    } else {
-      if (rcdata[i][0] != "space" && i == 33){
-        thumb = "l"
-      }
-      str += rcdata[i][0];
-    }
+  for (let i = 0; i <= 32; i++) {
+    str += rcdata[i][0]
   }
-  if (rcdata[35][0] != "$") {
-    str += rcdata[35][0];
+
+  maybe_space = rcdata[33][0]
+  if (maybe_space == "space"){
+    str += "space";
+    thumb = "r"
+  } else {
+    thumb = "l"
+    str += maybe_space
+  }
+
+  ch35 = rcdata[35][0]
+  if (ch35 != "$") {
+    str += ch35;
   }
   return str;
 }
@@ -915,32 +934,6 @@ function getY(name, row, col) {
   return 10 + row * w
 }
 
-function getCol(letter) {
-  for (let i = 0; i < rcdata.length; i++) {
-    if (rcdata[i][0] === letter) {
-      return rcdata[i][2];
-    }
-  }
-  return -1;
-}
-
-function getRow(letter) {
-  for (let i = 0; i < rcdata.length; i++) {
-    if (rcdata[i][0] === letter) {
-      return rcdata[i][1];
-    }
-  }
-  return -1;
-}
-function getChar(row,col) {
-  for (let i = 0; i < rcdata.length; i++) {
-    if (rcdata[i][1] == row && rcdata[i][2] == col) {
-      return rcdata[i][0];
-    }
-  }
-  return "!";
-}
-
 function getFinger(row, col) {
   if (row > 2) {
     if (col <= 4) {
@@ -954,12 +947,14 @@ function getFinger(row, col) {
 }
 
 function dist(x1, y1, x2, y2) {
-  return Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))/w;
+  dx = x1 - x2
+  dy = y1 - y2
+  return inv_w * Math.sqrt(dx*dx + dy*dy); // pow is slow
 }
 
 function generateCoords() {
   console.log("generateCoords")
-  for (let i = 0; i < rcdata.length; i++) {
+  for (let i = 0; i < rcdata_len; i++) {
     rcdata[i][4] = getY(rcdata[i][0], rcdata[i][1],rcdata[i][2]); // Y
     rcdata[i][5] = getX(rcdata[i][0], rcdata[i][1],rcdata[i][2]); // X
   }
@@ -976,7 +971,7 @@ function generateLayout() {
   }
   svg.append("rect").attr("x", 45).attr("y", 0).attr("width", outlinewidth).attr("height", 170)
   .attr("stroke", "#777777").attr("fill", "#1b1c1f").attr("fill-opactiy", "0.0").attr("rx", 8).attr("ry", 8)
-  for (let i = 0; i < rcdata.length; i++) {
+  for (let i = 0; i < rcdata_len; i++) {
     dtx = 0;
     letter = rcdata[i][0];
     if (letter == "^"){
@@ -1101,9 +1096,10 @@ function measureDictionary() {
     count += 1;
     total = 0.0;
     word = dictionary[wordi];
+    word_len = word.length // Compute once
     char1 = word.charAt(0);
     samehand = `${char1}`;
-    for (let i = 1; i < word.length; i++) {
+    for (let i = 1; i < word_len; i++) {
       char1 = word.charAt(i-1);
       char2 = word.charAt(i);
       col1 = getCol(char1);
@@ -1121,7 +1117,7 @@ function measureDictionary() {
         }
       }
     }
-    char1 = word.charAt(word.length-1);
+    char1 = word.charAt(word_len-1);
     char2 = "_"
     col1 = getCol(char1);
     row1 = getRow(char1);
@@ -1138,7 +1134,7 @@ function measureDictionary() {
       }
     }
 
-    for (let i = 2; i < word.length; i++) {
+    for (let i = 2; i < word_len; i++) {
       char1 = word.charAt(i-2);
       char2 = word.charAt(i);
       col1 = getCol(char1);
@@ -1156,7 +1152,7 @@ function measureDictionary() {
         }
       }
     }
-    char1 = word.charAt(word.length-2);
+    char1 = word.charAt(word_len-2);
     char2 = "_"
     col1 = getCol(char1);
     row1 = getRow(char1);
@@ -1358,7 +1354,8 @@ function measureWords() {
     word_count += 1
     finger_pos = [[0, 0], [1, 1], [1, 2], [1, 3], [1, 4], [3, 4], [3, 7], [1, 7], [1, 8], [1, 9], [1, 10]];
     var count = words[word];
-    m_input_length += count * (word.length + 1);
+    word_len = word.length // Compute once
+    m_input_length += count * (word_len + 1);
 
     if (word_effort[word]){
       // console.log(word +" "+word_effort[word]);
@@ -1367,7 +1364,7 @@ function measureWords() {
 
     char = word.charAt(0);
     samehand = char
-    for (let i = 0; i < word.length; i++) {
+    for (let i = 0; i < word_len; i++) {
       char = word.charAt(i);
       if (i > 0){prevchar = word.charAt(i-1);}
       // freq //
@@ -1662,7 +1659,7 @@ function measureWords() {
     sum += m_letter_freq[letter]
   }
   for (var letter in m_letter_freq) {
-    for (let i = 0; i < rcdata.length; i++) {
+    for (let i = 0; i < rcdata_len; i++) {
       if (rcdata[i][0] == letter) {
         rcdata[i][3] = 100 * m_letter_freq[letter] / sum
       }
@@ -2167,11 +2164,13 @@ function generatePlots() {
     }
     var count = samehandstrings[word];
     // console.log(word + " " + count)
-    var width = scale * word.length * count;
+    word_len = word.length
+    var word_len_count = word_len * count;
+    var width = scale * word_len_count;
     if (width > 100) {width = 100;}
     stats.append("rect").attr("x", x + 70).attr("y", y + i * 15).attr("width", width).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
     stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(word);
-    stats.append("text").attr("x", x + 135).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word.length*count)).toFixed(0));//
+    stats.append("text").attr("x", x + 135).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word_len_count)).toFixed(0));//
     i += 1;
     if (i > 10) { break; }
   }
@@ -2212,12 +2211,13 @@ function generatePlots() {
   var i = 0
   t = hw_scroll_amount;
   for (var word in word_effort) {
-    if (word.length > 3 && words[word] > 4){
+    word_len = word.length
+    if (word_len > 3 && words[word] > 4){
       if (t > 0){
         t -= 1;
         continue;
       }
-      var height = 100*word_effort[word]/word.length;
+      var height = 100*word_effort[word] / word_len;
       stats.append("rect").attr("x", x + 80).attr("y", y + i * 15).attr("width", height).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
       stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(word);
       stats.append("text").attr("x", x + 165).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word_effort[word])).toFixed(2));
@@ -2353,7 +2353,7 @@ function makeDraggable(svg) {
         closestdist = 9999;
         starti = -1;
         var keyname = ""
-        for (let i = 0; i < rcdata.length; i++) {
+        for (let i = 0; i < rcdata_len; i++) {
           d = dist(x, y, rcdata[i][5], rcdata[i][4]);
           if (d < closestdist) {
             closestdist = d;
@@ -2397,7 +2397,7 @@ function makeDraggable(svg) {
       // scan through rcdata to find out which key are we closest to
       closestdist = 9999;
       var keyname = ""
-      for (let i = 0; i < rcdata.length; i++) {
+      for (let i = 0; i < rcdata_len; i++) {
         d = dist(x, y, rcdata[i][5], rcdata[i][4]);
         keyname = rcdata[i][0];
         if (d < closestdist) {

--- a/keyboard_svg.js
+++ b/keyboard_svg.js
@@ -916,9 +916,10 @@ function getY(name, row, col) {
 }
 
 function getCol(letter) {
-  for (let i = 0; i < rcdata.length; i++) {
-    if (rcdata[i][0] === letter) {
-      return rcdata[i][2];
+  for (let i = 0; i < rcdata_len; i++) {
+    const key = rcdata[i];
+    if (key[0] === letter) {
+      return key[2];
     }
   }
   return -1;
@@ -926,16 +927,18 @@ function getCol(letter) {
 
 function getRow(letter) {
   for (let i = 0; i < rcdata_len; i++) {
-    if (rcdata[i][0] === letter) {
-      return rcdata[i][1];
+    const key = rcdata[i];
+    if (key[0] === letter) {
+      return key[1];
     }
   }
   return -1;
 }
 function getChar(row,col) {
   for (let i = 0; i < rcdata_len; i++) {
-    if (rcdata[i][1] == row && rcdata[i][2] == col) {
-      return rcdata[i][0];
+    const key = rcdata[i];
+    if (key[1] == row && key[2] == col) {
+      return key[0];
     }
   }
   return "!";

--- a/keyboard_svg.js
+++ b/keyboard_svg.js
@@ -6,8 +6,9 @@ var url_layout = params.layout;
 
 var swidth = 1000;
 var sheight = 180;
-var w = 38; // seems to be const?
-const inv_w = 1.0 / 38
+
+var w = 38;
+const inv_w = 1.0 / 38;
 var gap = 8;
 var letter = "";
 var x = 0;
@@ -220,27 +221,6 @@ var rcdata = [
   ["space", 3, 7, 0, 0, 0, 1, 39],
 ]
 const rcdata_len = rcdata.length // Compute once
-
-const column_map = {}; // Fast column lookup
-for (let i = 0; i < rcdata_len; i++) {
-  column_map[rcdata[i][0]] = rcdata[i][2];
-}
-const getCol = letter => column_map[letter] ?? -1;
-
-const row_map = {}; // Fast row lookup
-for (let i = 0; i < rcdata_len; i++) {
-  row_map[rcdata[i][0]] = rcdata[i][1];
-}
-const getRow = letter => row_map[letter] ?? -1;
-
-const char_map = {}; // Fast char lookup
-for (let i = 0; i < rcdata_len; i++) {
-  // (row * w + col) is unique per character
-  row = rcdata[i][1]
-  column = rcdata[i][2]
-  char_map[row * w + column] = rcdata[i][0];
-}
-const getChar = (row,col) => char_map[row * w + column] ?? "!";
 
 var effort = [
   [
@@ -852,21 +832,20 @@ function importLayout(layout) {
 function exportLayout() {
   var str = "";
   for (let i = 0; i <= 32; i++) {
-    str += rcdata[i][0]
+    str += rcdata[i][0];
   }
 
-  maybe_space = rcdata[33][0]
+  maybe_space = rcdata[33][0];
   if (maybe_space == "space"){
     str += "space";
-    thumb = "r"
+    thumb = "r";
   } else {
-    thumb = "l"
-    str += maybe_space
+    thumb = "l";
+    str += maybe_space;
   }
 
-  ch35 = rcdata[35][0]
-  if (ch35 != "$") {
-    str += ch35;
+  if (rcdata[35][0] != "$") {
+    str += rcdata[35][0];
   }
   return str;
 }
@@ -936,6 +915,32 @@ function getY(name, row, col) {
   return 10 + row * w
 }
 
+function getCol(letter) {
+  for (let i = 0; i < rcdata_len; i++) {
+    if (rcdata[i][0] === letter) {
+      return rcdata[i][2];
+    }
+  }
+  return -1;
+}
+
+function getRow(letter) {
+  for (let i = 0; i < rcdata_len; i++) {
+    if (rcdata[i][0] === letter) {
+      return rcdata[i][1];
+    }
+  }
+  return -1;
+}
+function getChar(row,col) {
+  for (let i = 0; i < rcdata_len; i++) {
+    if (rcdata[i][1] == row && rcdata[i][2] == col) {
+      return rcdata[i][0];
+    }
+  }
+  return "!";
+}
+
 function getFinger(row, col) {
   if (row > 2) {
     if (col <= 4) {
@@ -951,7 +956,7 @@ function getFinger(row, col) {
 function dist(x1, y1, x2, y2) {
   dx = x1 - x2
   dy = y1 - y2
-  return inv_w * Math.sqrt(dx*dx + dy*dy); // pow is slow
+  return Math.sqrt(dx*dx + dy*dy) * inv_w;
 }
 
 function generateCoords() {
@@ -1098,10 +1103,9 @@ function measureDictionary() {
     count += 1;
     total = 0.0;
     word = dictionary[wordi];
-    word_len = word.length // Compute once
     char1 = word.charAt(0);
     samehand = `${char1}`;
-    for (let i = 1; i < word_len; i++) {
+    for (let i = 1; i < word.length; i++) {
       char1 = word.charAt(i-1);
       char2 = word.charAt(i);
       col1 = getCol(char1);
@@ -1119,7 +1123,7 @@ function measureDictionary() {
         }
       }
     }
-    char1 = word.charAt(word_len-1);
+    char1 = word.charAt(word.length-1);
     char2 = "_"
     col1 = getCol(char1);
     row1 = getRow(char1);
@@ -1136,7 +1140,7 @@ function measureDictionary() {
       }
     }
 
-    for (let i = 2; i < word_len; i++) {
+    for (let i = 2; i < word.length; i++) {
       char1 = word.charAt(i-2);
       char2 = word.charAt(i);
       col1 = getCol(char1);
@@ -1154,7 +1158,7 @@ function measureDictionary() {
         }
       }
     }
-    char1 = word.charAt(word_len-2);
+    char1 = word.charAt(word.length-2);
     char2 = "_"
     col1 = getCol(char1);
     row1 = getRow(char1);
@@ -1356,8 +1360,7 @@ function measureWords() {
     word_count += 1
     finger_pos = [[0, 0], [1, 1], [1, 2], [1, 3], [1, 4], [3, 4], [3, 7], [1, 7], [1, 8], [1, 9], [1, 10]];
     var count = words[word];
-    word_len = word.length // Compute once
-    m_input_length += count * (word_len + 1);
+    m_input_length += count * (word.length + 1);
 
     if (word_effort[word]){
       // console.log(word +" "+word_effort[word]);
@@ -1366,7 +1369,7 @@ function measureWords() {
 
     char = word.charAt(0);
     samehand = char
-    for (let i = 0; i < word_len; i++) {
+    for (let i = 0; i < word.length; i++) {
       char = word.charAt(i);
       if (i > 0){prevchar = word.charAt(i-1);}
       // freq //
@@ -2166,13 +2169,11 @@ function generatePlots() {
     }
     var count = samehandstrings[word];
     // console.log(word + " " + count)
-    word_len = word.length
-    var word_len_count = word_len * count;
-    var width = scale * word_len_count;
+    var width = scale * word.length * count;
     if (width > 100) {width = 100;}
     stats.append("rect").attr("x", x + 70).attr("y", y + i * 15).attr("width", width).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
     stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(word);
-    stats.append("text").attr("x", x + 135).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word_len_count)).toFixed(0));//
+    stats.append("text").attr("x", x + 135).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word.length*count)).toFixed(0));//
     i += 1;
     if (i > 10) { break; }
   }
@@ -2213,13 +2214,12 @@ function generatePlots() {
   var i = 0
   t = hw_scroll_amount;
   for (var word in word_effort) {
-    word_len = word.length
-    if (word_len > 3 && words[word] > 4){
+    if (word.length > 3 && words[word] > 4){
       if (t > 0){
         t -= 1;
         continue;
       }
-      var height = 100*word_effort[word] / word_len;
+      var height = 100*word_effort[word]/word.length;
       stats.append("rect").attr("x", x + 80).attr("y", y + i * 15).attr("width", height).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
       stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(word);
       stats.append("text").attr("x", x + 165).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word_effort[word])).toFixed(2));

--- a/keyboard_svg.js
+++ b/keyboard_svg.js
@@ -6,9 +6,8 @@ var url_layout = params.layout;
 
 var swidth = 1000;
 var sheight = 180;
-
-var w = 38;
-const inv_w = 1.0 / 38;
+var w = 38; // seems to be const?
+const inv_w = 1.0 / 38
 var gap = 8;
 var letter = "";
 var x = 0;
@@ -832,20 +831,21 @@ function importLayout(layout) {
 function exportLayout() {
   var str = "";
   for (let i = 0; i <= 32; i++) {
-    str += rcdata[i][0];
+    str += rcdata[i][0]
   }
 
-  maybe_space = rcdata[33][0];
+  maybe_space = rcdata[33][0]
   if (maybe_space == "space"){
     str += "space";
-    thumb = "r";
+    thumb = "r"
   } else {
-    thumb = "l";
-    str += maybe_space;
+    thumb = "l"
+    str += maybe_space
   }
 
-  if (rcdata[35][0] != "$") {
-    str += rcdata[35][0];
+  ch35 = rcdata[35][0]
+  if (ch35 != "$") {
+    str += ch35;
   }
   return str;
 }
@@ -916,7 +916,7 @@ function getY(name, row, col) {
 }
 
 function getCol(letter) {
-  for (let i = 0; i < rcdata_len; i++) {
+  for (let i = 0; i < rcdata.length; i++) {
     if (rcdata[i][0] === letter) {
       return rcdata[i][2];
     }
@@ -956,7 +956,7 @@ function getFinger(row, col) {
 function dist(x1, y1, x2, y2) {
   dx = x1 - x2
   dy = y1 - y2
-  return Math.sqrt(dx*dx + dy*dy) * inv_w;
+  return inv_w * Math.sqrt(dx*dx + dy*dy); // pow is slow
 }
 
 function generateCoords() {
@@ -1103,9 +1103,10 @@ function measureDictionary() {
     count += 1;
     total = 0.0;
     word = dictionary[wordi];
+    word_len = word.length // Compute once
     char1 = word.charAt(0);
     samehand = `${char1}`;
-    for (let i = 1; i < word.length; i++) {
+    for (let i = 1; i < word_len; i++) {
       char1 = word.charAt(i-1);
       char2 = word.charAt(i);
       col1 = getCol(char1);
@@ -1123,7 +1124,7 @@ function measureDictionary() {
         }
       }
     }
-    char1 = word.charAt(word.length-1);
+    char1 = word.charAt(word_len-1);
     char2 = "_"
     col1 = getCol(char1);
     row1 = getRow(char1);
@@ -1140,7 +1141,7 @@ function measureDictionary() {
       }
     }
 
-    for (let i = 2; i < word.length; i++) {
+    for (let i = 2; i < word_len; i++) {
       char1 = word.charAt(i-2);
       char2 = word.charAt(i);
       col1 = getCol(char1);
@@ -1158,7 +1159,7 @@ function measureDictionary() {
         }
       }
     }
-    char1 = word.charAt(word.length-2);
+    char1 = word.charAt(word_len-2);
     char2 = "_"
     col1 = getCol(char1);
     row1 = getRow(char1);
@@ -1360,7 +1361,8 @@ function measureWords() {
     word_count += 1
     finger_pos = [[0, 0], [1, 1], [1, 2], [1, 3], [1, 4], [3, 4], [3, 7], [1, 7], [1, 8], [1, 9], [1, 10]];
     var count = words[word];
-    m_input_length += count * (word.length + 1);
+    word_len = word.length // Compute once
+    m_input_length += count * (word_len + 1);
 
     if (word_effort[word]){
       // console.log(word +" "+word_effort[word]);
@@ -1369,7 +1371,7 @@ function measureWords() {
 
     char = word.charAt(0);
     samehand = char
-    for (let i = 0; i < word.length; i++) {
+    for (let i = 0; i < word_len; i++) {
       char = word.charAt(i);
       if (i > 0){prevchar = word.charAt(i-1);}
       // freq //
@@ -2169,11 +2171,13 @@ function generatePlots() {
     }
     var count = samehandstrings[word];
     // console.log(word + " " + count)
-    var width = scale * word.length * count;
+    word_len = word.length
+    var word_len_count = word_len * count;
+    var width = scale * word_len_count;
     if (width > 100) {width = 100;}
     stats.append("rect").attr("x", x + 70).attr("y", y + i * 15).attr("width", width).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
     stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(word);
-    stats.append("text").attr("x", x + 135).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word.length*count)).toFixed(0));//
+    stats.append("text").attr("x", x + 135).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word_len_count)).toFixed(0));//
     i += 1;
     if (i > 10) { break; }
   }
@@ -2214,12 +2218,13 @@ function generatePlots() {
   var i = 0
   t = hw_scroll_amount;
   for (var word in word_effort) {
-    if (word.length > 3 && words[word] > 4){
+    word_len = word.length
+    if (word_len > 3 && words[word] > 4){
       if (t > 0){
         t -= 1;
         continue;
       }
-      var height = 100*word_effort[word]/word.length;
+      var height = 100*word_effort[word] / word_len;
       stats.append("rect").attr("x", x + 80).attr("y", y + i * 15).attr("width", height).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
       stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(word);
       stats.append("text").attr("x", x + 165).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (word_effort[word])).toFixed(2));

--- a/keyboard_svg.js
+++ b/keyboard_svg.js
@@ -236,6 +236,8 @@ const getRow = letter => row_map[letter] ?? -1;
 const char_map = {}; // Fast char lookup
 for (let i = 0; i < rcdata_len; i++) {
   // (row * w + col) is unique per character
+  row = rcdata[i][1]
+  column = rcdata[i][2]
   char_map[row * w + column] = rcdata[i][0];
 }
 const getChar = (row,col) => char_map[row * w + column] ?? "!";

--- a/keyboard_svg.js
+++ b/keyboard_svg.js
@@ -6,16 +6,17 @@ var url_layout = params.layout;
 
 var swidth = 1000;
 var sheight = 180;
-var w = 38; // seems to be const?
+const w = 38;
 const inv_w = 1.0 / 38
-var gap = 8;
+const gap = 8;
 var letter = "";
 var x = 0;
 var y = 0;
 var dx;
 var fontsize;
 var per;
-var max = 11.870939;
+const default_max = 11.870939;
+const inv_default_max = 1.0 / default_max;
 var red = 0;
 var scroll_amount = 0;
 var hw_scroll_amount = 0;
@@ -991,7 +992,7 @@ function generateLayout() {
     y = rcdata[i][4];
     per = rcdata[i][3];
     keywidth = rcdata[i][6];
-    red = Math.floor(127 * per / max) + 128
+    red = Math.floor(127 * per * inv_default_max) + 128
     if (red < 16) {  red = 16; }
     if (red > 255) { red = 255;}
     hex_red = red.toString(16);
@@ -1024,7 +1025,7 @@ function generateLayout() {
   }
   svg.append("text").attr("x", 640).attr("y", 135).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Total Word Effort "+(m_total_word_effort/100.0).toFixed(1))
   // effort text
-  svg.append("text").attr("x", 640).attr("y", 165).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Effort "+(577*m_effort/m_input_length).toFixed(2))
+  svg.append("text").attr("x", 640).attr("y", 165).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Effort " + (577 * m_effort * inv_m_input_length).toFixed(2))
   // edit button
   svg.append("rect").attr("x", 760).attr("y", 147).attr("width", 40).attr("height", 25).attr("rx",0).attr("ry",0)
   .attr("fill","#777777").attr("stroke","black").attr("stroke-width","1").attr("onclick", "openPopup()")
@@ -1087,6 +1088,7 @@ var m_trigram_count_roll_in = {};
 var m_trigram_count_roll_out = {};
 var m_pinky_off = 0;
 var m_input_length = 0;
+var inv_m_input_length = 1;
 var m_effort = 0;
 var m_total_word_effort = 0;
 // var m_simple_effort = {};
@@ -1181,7 +1183,7 @@ function measureDictionary() {
     if (isNaN(total)){
       console.log(word + " gives NaN for effort")
     }
-    word_effort[word] = total/10;
+    word_effort[word] = 0.1 * total;
   }
 }
 
@@ -1661,17 +1663,19 @@ function measureWords() {
     }
     samehandcount[samehand.length] += count
   }
-  var scale = 1006393/m_input_length;
+  inv_m_input_length = 1.0 / m_input_length;
+  var scale = 1006393 * inv_m_input_length;
   m_total_word_effort *= scale;
   // console.log("word count "+word_count)
   var sum = 0;
   for (var letter in m_letter_freq) {
     sum += m_letter_freq[letter]
   }
+  const hundred_inv_sum = 100.0 / sum;
   for (var letter in m_letter_freq) {
     for (let i = 0; i < rcdata_len; i++) {
       if (rcdata[i][0] == letter) {
-        rcdata[i][3] = 100 * m_letter_freq[letter] / sum
+        rcdata[i][3] = hundred_inv_sum * m_letter_freq[letter]
       }
     }
   }
@@ -1686,14 +1690,15 @@ function generatePlots() {
   var x = 500;
   var y = 0;
   stats.append("text").attr("x", x + 40).attr("y", 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Column Usage")
-  var sum = 0;
+  var sum_col_usage = 0;
   for (var col in m_column_usage) {
-    sum += m_column_usage[col];
+    sum_col_usage += m_column_usage[col];
   }
+  const inv_sum_col_usage = 1.0 / sum_col_usage;
   for (var col in m_column_usage) {
-    var height = 300 * m_column_usage[col] / sum;
-    var tip = parseFloat(100 * m_column_usage[col] / sum).toFixed(2);
-    var red = Math.floor(275 * m_column_usage[col] / sum) + 128
+    var height = 300 * m_column_usage[col] * inv_sum_col_usage;
+    var tip = parseFloat(100 * m_column_usage[col] * inv_sum_col_usage).toFixed(2);
+    var red = Math.floor(275 * m_column_usage[col] * inv_sum_col_usage) + 128
     var green = 128;
     if (red < 16) { red = 16; }
     if (red > 255) { red = 255; }
@@ -1711,14 +1716,15 @@ function generatePlots() {
   var x = 770;
   var y = 0;
   stats.append("text").attr("x", x + 40).attr("y", 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Row Usage")
-  var sum = 0;
+  var sum_row_usage = 0;
   for (var row in m_row_usage) {
-    sum += m_row_usage[row];
+    sum_row_usage += m_row_usage[row];
   }
+  const inv_sum_row_usage = 1.0 / sum_row_usage;
   for (var row in m_row_usage) {
-    var height = 200 * m_row_usage[row] / sum;
-    var tip = parseFloat(100 * m_row_usage[row] / sum).toFixed(2);
-    var red = Math.floor(190 * m_row_usage[row] / sum) + 128
+    var height = 200 * m_row_usage[row] * inv_sum_row_usage;
+    var tip = parseFloat(100 * m_row_usage[row] * inv_sum_row_usage).toFixed(2);
+    var red = Math.floor(190 * m_row_usage[row] * inv_sum_row_usage) + 128
     var green = 128;
     if (red < 16) { red = 16; }
     if (red > 255) { red = 255; }
@@ -1747,10 +1753,12 @@ function generatePlots() {
       right += m_finger_usage[finger];
     }
   }
+  var inv_sum = 1.0 / sum;
   for (var finger in m_finger_usage) {
-    var height = 300 * m_finger_usage[finger] / sum;
-    var tip = parseFloat(100 * m_finger_usage[finger] / sum).toFixed(2);
-    var red = Math.floor(275 * m_finger_usage[finger] / sum) + 128
+    var norm_finger_usage = m_finger_usage[finger] * inv_sum
+    var height = 300 * norm_finger_usage;
+    var tip = parseFloat(100 * norm_finger_usage).toFixed(2);
+    var red = Math.floor(275 * norm_finger_usage) + 128
     var green = 128;
     if (red < 16) { red = 16; }
     if (red > 255) { red = 255; }
@@ -1762,12 +1770,12 @@ function generatePlots() {
     stats.append("text").attr("x", x + finger * 20 + 7).attr("y", 111).attr("fill", "#dfe2eb").attr("font-size", 10)
       .attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(finger)
   }
-  stats.append("text").attr("x", x + 57).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * left / sum).toFixed(2) + "%");
-  stats.append("text").attr("x", x + 177).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * right / sum).toFixed(2) + "%");
+  stats.append("text").attr("x", x + 57).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * left * inv_sum).toFixed(2) + "%");
+  stats.append("text").attr("x", x + 177).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * right * inv_sum).toFixed(2) + "%");
   ///////////////////////////////////////   F I N G E R   D I S T A N C E   //////////////////////////////////
   var x = 250;
   var y = 0;
-  var max = m_input_length / 5.110882176;
+  var max = m_input_length / 5.110882176;  // this might be shadowing 'max' above
   sum = 0
   left = 0;
   right = 0;
@@ -1780,13 +1788,15 @@ function generatePlots() {
       right += m_finger_distance[finger];
     }
   }
-
+  var inv_max = 1.0 / max;
+  inv_sum = 1.0 / sum;
   stats.append("text").attr("x", x + 40).attr("y", 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Finger Distance")
   for (var finger in m_finger_distance) {
     if (m_finger_distance[finger] > 0) {
-    var height = 75 * m_finger_distance[finger] / max;
-    var tip = parseFloat(100 * m_finger_distance[finger] / max).toFixed(2);
-    var red = Math.floor(128 * m_finger_distance[finger] / max) + 128
+    var norm_finger_distance = m_finger_distance[finger] * inv_max;
+    var height = 75 * norm_finger_distance;
+    var tip = parseFloat(100 * norm_finger_distance).toFixed(2);
+    var red = Math.floor(128 * norm_finger_distance) + 128
     var green = 128;
     if (red < 16) { red = 16; }
     if (red > 255) { red = 255; }
@@ -1799,9 +1809,9 @@ function generatePlots() {
     //<rect x="#{x+column*20}" y="#{y+100-height}" width="15" height="#{height}" fill="##{ab}7787" stroke="#453033" stroke-width="1" onmousemove="showTooltip(evt,'#{(100*value/sum.to_f).round(2)}%')" onmouseout="hideTooltip()" />\n"
     }
   }
-  stats.append("text").attr("x", x + 57).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * left / sum).toFixed(2) + "%");
-  stats.append("text").attr("x", x + 177).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * right / sum).toFixed(2) + "%");
-  stats.append("text").attr("x", x + 117).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * sum/max).toFixed(1));
+  stats.append("text").attr("x", x + 57).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * left * inv_sum).toFixed(2) + "%");
+  stats.append("text").attr("x", x + 177).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * right * inv_sum).toFixed(2) + "%");
+  stats.append("text").attr("x", x + 117).attr("y", 124).attr("fill", "#dfe2eb").attr("font-size", 11).attr("font-family", "Sans,Arial").attr("text-anchor", "middle").text(parseFloat(100 * sum * inv_max).toFixed(1));
   // (100*sum/max).toFixed(1)
   ///////////////////////////////////   S A M E   F I N G E R   B I G R A M S    ///////////////////////////////
   var x = 0;
@@ -1823,7 +1833,7 @@ function generatePlots() {
     m_same_finger = Object.fromEntries(keyValueArray);
 
     for (var bigram in m_same_finger) {
-      sum += m_same_finger[bigram] / m_input_length;
+      sum += m_same_finger[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Finger Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
     // stats.append("text").attr("x",x+40).attr("y",y+200).attr("font-size",16).attr("font-family","Sans,Arial").attr("fill","#dfe2eb").attr("text-anchor","left").text("Input Length "+m_input_length);
@@ -1835,26 +1845,26 @@ function generatePlots() {
         t -= 1;
         continue;
       }
-      var width = 18000 * m_same_finger[bigram] / m_input_length;
+      var width = 18000 * m_same_finger[bigram] * inv_m_input_length;
       if (width > 200) { width = 200; }
       stats.append("rect").attr("x", x + 40).attr("y", y + i * 15).attr("width", width).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
       stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(bigram);
-      stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * m_same_finger[bigram] / m_input_length)).toFixed(2) + "%");
+      stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * m_same_finger[bigram] * inv_m_input_length)).toFixed(2) + "%");
       //<rect x="#{x+column*20}" y="#{y+100-height}" width="15" height="#{height}" fill="##{ab}7787" stroke="#453033" stroke-width="1" onmousemove="showTooltip(evt,'#{(100*value/sum.to_f).round(2)}%')" onmouseout="hideTooltip()" />\n"
       i += 1;
       if (i > 10) { break; }
     }
   } else if(sfb_toggle == 1){
     for (var finger in m_same_finger2) {
-      sum += m_same_finger2[finger] / m_input_length;
+      sum += m_same_finger2[finger] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial")
        .attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Finger Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
     for (var finger in m_same_finger2) {
-      var height = 30000 * m_same_finger2[finger] / m_input_length;
+      var height = 30000 * m_same_finger2[finger] * inv_m_input_length;
       if (height > 150) { height = 150;}
-      var tip = parseFloat(100 * m_same_finger2[finger] / m_input_length).toFixed(2);
-      var red = Math.floor(6000 * m_same_finger2[finger] / m_input_length) + 128
+      var tip = parseFloat(100 * m_same_finger2[finger] * inv_m_input_length).toFixed(2);
+      var red = Math.floor(6000 * m_same_finger2[finger] * inv_m_input_length) + 128
       var green = 128;
       if (red < 16) { red = 16; }
       if (red > 255) { red = 255; }
@@ -1874,7 +1884,7 @@ function generatePlots() {
     m_same_finger3 = Object.fromEntries(keyValueArray);
 
     for (var bigram in m_same_finger3) {
-      sum += m_same_finger3[bigram] / m_input_length;
+      sum += m_same_finger3[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("2u Same Finger Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
     // stats.append("text").attr("x",x+40).attr("y",y+200).attr("font-size",16).attr("font-family","Sans,Arial").attr("fill","#dfe2eb").attr("text-anchor","left").text("Input Length "+m_input_length);
@@ -1886,11 +1896,11 @@ function generatePlots() {
         t -= 1;
         continue;
       }
-      var width = 18000 * m_same_finger3[bigram] / m_input_length;
+      var width = 18000 * m_same_finger3[bigram] * inv_m_input_length;
       if (width > 200) { width = 200; }
       stats.append("rect").attr("x", x + 40).attr("y", y + i * 15).attr("width", width).attr("height", 10).attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
       stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(bigram);
-      stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * m_same_finger3[bigram] / m_input_length)).toFixed(2) + "%");
+      stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * m_same_finger3[bigram] * inv_m_input_length)).toFixed(2) + "%");
       //<rect x="#{x+column*20}" y="#{y+100-height}" width="15" height="#{height}" fill="##{ab}7787" stroke="#453033" stroke-width="1" onmousemove="showTooltip(evt,'#{(100*value/sum.to_f).round(2)}%')" onmouseout="hideTooltip()" />\n"
       i += 1;
       if (i > 10) { break; }
@@ -1907,7 +1917,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
     for (var bigram in tmp) {
-      sum += tmp[bigram] / m_input_length;
+      sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Skip Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
   } else {
@@ -1915,7 +1925,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
     for (var bigram in tmp) {
-      sum += tmp[bigram] / m_input_length;
+      sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Skip Bigrams (2u) " + parseFloat(100 * sum).toFixed(2) + "%")
   }
@@ -1934,12 +1944,12 @@ function generatePlots() {
       t -= 1;
       continue;
     }
-    var height = 36000 * tmp[bigram] / m_input_length;
+    var height = 36000 * tmp[bigram] * inv_m_input_length;
     if (height > 200) { height = 200; }
     stats.append("rect").attr("x", x + 40).attr("y", y + i * 15).attr("width", height).attr("height", 10)
       .attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
     stats.append("text").attr("x", x + 17).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(bigram);
-    stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp[bigram] / m_input_length)).toFixed(2) + "%");
+    stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp[bigram] * inv_m_input_length)).toFixed(2) + "%");
     //<rect x="#{x+column*20}" y="#{y+100-height}" width="15" height="#{height}" fill="##{ab}7787" stroke="#453033" stroke-width="1" onmousemove="showTooltip(evt,'#{(100*value/sum.to_f).round(2)}%')" onmouseout="hideTooltip()" />\n"
     i += 1;
     if (i > 10) { break; }
@@ -1953,7 +1963,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
     for (var bigram in tmp) {
-      sum += tmp[bigram] / m_input_length;
+      sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Lat Stretch Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
   } else {
@@ -1961,7 +1971,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
     for (var bigram in tmp) {
-      sum += tmp[bigram] / m_input_length;
+      sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Ring LSBs " + parseFloat(100 * sum).toFixed(2) + "%")
   }
@@ -1980,12 +1990,12 @@ function generatePlots() {
       t -= 1;
       continue;
     }
-    var height = 10000 * tmp[bigram] / m_input_length;
+    var height = 10000 * tmp[bigram] * inv_m_input_length;
     if (height > 200) { height = 200; }
     stats.append("rect").attr("x", x + 40).attr("y", y + i * 15).attr("width", height).attr("height", 10)
       .attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
     stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(bigram);
-    stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp[bigram] / m_input_length)).toFixed(2) + "%");
+    stats.append("text").attr("x", x + 200).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp[bigram] * inv_m_input_length)).toFixed(2) + "%");
     //<rect x="#{x+column*20}" y="#{y+100-height}" width="15" height="#{height}" fill="##{ab}7787" stroke="#453033" stroke-width="1" onmousemove="showTooltip(evt,'#{(100*value/sum.to_f).round(2)}%')" onmouseout="hideTooltip()" />\n"
     i += 1;
     if (i > 10) { break; }
@@ -2000,7 +2010,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
     for (var bigram in tmp) {
-      sum += tmp[bigram] / m_input_length;
+      sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Pinky/Ring Scissors " + parseFloat(100 * sum).toFixed(2) + "%")
   } else if (scissors_toggle == 0){
@@ -2008,7 +2018,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
     for (var bigram in tmp) {
-      sum += tmp[bigram] / m_input_length;
+      sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Scissors " + parseFloat(100 * sum).toFixed(2) + "%")
   } else {
@@ -2016,7 +2026,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
     for (var bigram in tmp) {
-      sum += tmp[bigram] / m_input_length;
+      sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Wide Scissors " + parseFloat(100 * sum).toFixed(2) + "%")
   }
@@ -2034,12 +2044,12 @@ function generatePlots() {
       t -= 1;
       continue;
     }
-    var height = 36000 * tmp[bigram] / m_input_length;
+    var height = 36000 * tmp[bigram] * inv_m_input_length;
     if (height > 180) { height = 180; }
     stats.append("rect").attr("x", x + 40).attr("y", y + i * 15).attr("width", height).attr("height", 10)
       .attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
     stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(bigram);
-    stats.append("text").attr("x", x + 190).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp[bigram] / m_input_length)).toFixed(2) + "%");
+    stats.append("text").attr("x", x + 190).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp[bigram] * inv_m_input_length)).toFixed(2) + "%");
     //<rect x="#{x+column*20}" y="#{y+100-height}" width="15" height="#{height}" fill="##{ab}7787" stroke="#453033" stroke-width="1" onmousemove="showTooltip(evt,'#{(100*value/sum.to_f).round(2)}%')" onmouseout="hideTooltip()" />\n"
     i += 1;
     if (i > 10) { break; }
@@ -2135,18 +2145,20 @@ function generatePlots() {
 
   var i = 0
   var t = trigram_scroll_amount;
+  inv_sum = 1.0 / sum;
   for (var cat in tmp) {
     if (t > 0){
       t -= 1;
       continue;
     }
-    var width = scale * 200 * tmp[cat] / sum;
+    var tmp_cat_inv_sum = tmp[cat] * inv_sum;
+    var width = scale * 200 * tmp_cat_inv_sum;
     if (width > 200) { width = 200; }
     stats.append("rect").attr("x", x + dx).attr("y", y + i * 15).attr("width", width).attr("height", 10)
       .attr("fill", "#7777bb").attr("stroke", "#9898d6").attr("stroke-width", 1)
       .attr("onmouseover","showTooltip(evt,'"+trigram_desc[cat]+"')").attr("onmouseout","hideTooltip()")
     stats.append("text").attr("x", x + 20).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 9).attr("font-family", "Roboto Mono").attr("text-anchor", "right").text(cat);
-    stats.append("text").attr("x", x + 190).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp[cat] / sum)).toFixed(2) + "%");
+    stats.append("text").attr("x", x + 190).attr("y", y + i * 15 + 8).attr("fill", "#dfe2eb").attr("font-size", 10).attr("font-family", "Sans,Arial").attr("text-anchor", "left").text(parseFloat("" + (100 * tmp_cat_inv_sum)).toFixed(2) + "%");
     //<rect x="#{x+column*20}" y="#{y+100-height}" width="15" height="#{height}" fill="##{ab}7787" stroke="#453033" stroke-width="1" onmousemove="showTooltip(evt,'#{(100*value/sum.to_f).round(2)}%')" onmouseout="hideTooltip()" />\n"
     i += 1;
     if (i > 10) { break; }
@@ -2161,7 +2173,7 @@ function generatePlots() {
   keyValueArray.sort((a, b) => b[1]*b[0].length - a[1]*a[0].length);
   samehandstrings = Object.fromEntries(keyValueArray);
 
-  scale = 30191.79 / m_input_length
+  scale = 30191.79 * inv_m_input_length
   // console.log("input length: "+m_input_length)
   // console.log("scale       : "+scale)
   stats.append("text").attr("x", x + 20).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Hand Strings")
@@ -2193,7 +2205,7 @@ function generatePlots() {
   // var keyValueArray = Object.entries(samehandcount);
   // keyValueArray.sort((a, b) => b - a);
   // samehandcount = Object.fromEntries(keyValueArray);
-  scale = 140.89502 / m_input_length
+  scale = 140.89502 * inv_m_input_length
   // console.log("input length: "+m_input_length)
   // console.log("scale       : "+scale)
   stats.append("text").attr("x", x + 20).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Hand Count")

--- a/keyboard_svg.js
+++ b/keyboard_svg.js
@@ -8,6 +8,8 @@ var swidth = 1000;
 var sheight = 180;
 const w = 38;
 const inv_w = 1.0 / 38
+const nb_row = 3;
+const nb_columns = 12;
 const gap = 8;
 var letter = "";
 var x = 0;
@@ -140,7 +142,7 @@ function selectLanguage(lan, event) {
   .then(data => {
       if (event && event.ctrlKey){
         console.log("adding "+lan+" to words")
-        for (var word in data) {
+        for (let word in data) {
           if (words[word]){
             words[word] += data[word]
           } else {
@@ -283,8 +285,8 @@ var effort = [
 // 2  \  z  x  c  v  b  n  m  ,  .  /
 
 function openPopup() {
-  for (var row = 0; row < 3; row++){
-    for (var col = 0; col < 12; col++){
+  for (let row = 0; row < nb_row; row++){
+    for (let col = 0; col < nb_columns; col++){
       var name = "textInput-" + row + "-" + col
       document.getElementById(name).value = effort[row][col];
     }
@@ -438,8 +440,8 @@ function closeCorpusPopup() {
 }
 
 function closePopup() {
-  for (var row = 0; row < 3; row++){
-    for (var col = 0; col < 12; col++){
+  for (let row = 0; row < nb_row; row++){
+    for (let col = 0; col < nb_columns; col++){
       var name = "textInput-" + row + "-" + col
       effort[row][col] = document.getElementById(name).value;
     }
@@ -452,9 +454,9 @@ function closePopup() {
 
 function copyEffortGridToClipboard() {
   values = []
-  for (var row = 0; row < 3; row++){
-    for (var col = 0; col < 12; col++){
-      var name = "textInput-" + row + "-" + col
+  for (let row = 0; row < 3; row++){
+    for (let col = 0; col < 12; col++){
+      const name = "textInput-" + row + "-" + col
       values.push(document.getElementById(name).value);
     }
   }
@@ -489,9 +491,9 @@ function pasteEffortGridFromClipboard() {
       return
     }
 
-    for (var row = 0; row < 3; row++){
-      for (var col = 0; col < 12; col++){
-        var name = "textInput-" + row + "-" + col
+    for (let row = 0; row < 3; row++){
+      for (let col = 0; col < 12; col++){
+        const name = "textInput-" + row + "-" + col
         document.getElementById(name).value = numbersArray[row * 12 + col]
       }
     }
@@ -1190,7 +1192,7 @@ function measureDictionary() {
 function getDictionaryFromWords() {
   console.log("getDictionaryFromWords");
   dictionary = [];
-  for (var word in words) {
+  for (let word in words) {
     if (words[word] > 100) {
       dictionary.push(word);
     }
@@ -1199,7 +1201,7 @@ function getDictionaryFromWords() {
 
 function getIndexOfKey(name){
   var x = -1;
-  for (var i = 0; i < 34; i++) {
+  for (let i = 0; i < 34; i++) {
     if (rcdata[i][7] == name) {
       x = i;
     }
@@ -1210,12 +1212,12 @@ function getIndexOfKey(name){
 function updateRcData(lan) {
   // what are the 33 letters ?
   var letters = []
-  for (var word in words) {
+  for (let word in words) {
     if (letters.length>=32){
       break;
     }
     var wordLetters = word.split(""); // Split the word into individual letters
-    for (var i = 0; i < wordLetters.length; i++) {
+    for (let i = 0; i < wordLetters.length; i++) {
       if (letters.indexOf(wordLetters[i]) === -1) {
         letters.push(wordLetters[i]); // Add letter to the list if not already present
       }
@@ -1361,11 +1363,11 @@ function measureWords() {
   var m_effort_per_letter = {};
   var m_effort_per_word = {};
   var word_count = 0
-  for (var word in words) {
+  for (let word in words) {
     if (word_count > 40000){break;}
     word_count += 1
     finger_pos = [[0, 0], [1, 1], [1, 2], [1, 3], [1, 4], [3, 4], [3, 7], [1, 7], [1, 8], [1, 9], [1, 10]];
-    var count = words[word];
+    const count = words[word];
     word_len = word.length // Compute once
     m_input_length += count * (word_len + 1);
 
@@ -1668,11 +1670,11 @@ function measureWords() {
   m_total_word_effort *= scale;
   // console.log("word count "+word_count)
   var sum = 0;
-  for (var letter in m_letter_freq) {
+  for (let letter in m_letter_freq) {
     sum += m_letter_freq[letter]
   }
   const hundred_inv_sum = 100.0 / sum;
-  for (var letter in m_letter_freq) {
+  for (let letter in m_letter_freq) {
     for (let i = 0; i < rcdata_len; i++) {
       if (rcdata[i][0] == letter) {
         rcdata[i][3] = hundred_inv_sum * m_letter_freq[letter]
@@ -1691,11 +1693,11 @@ function generatePlots() {
   var y = 0;
   stats.append("text").attr("x", x + 40).attr("y", 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Column Usage")
   var sum_col_usage = 0;
-  for (var col in m_column_usage) {
+  for (let col in m_column_usage) {
     sum_col_usage += m_column_usage[col];
   }
   const inv_sum_col_usage = 1.0 / sum_col_usage;
-  for (var col in m_column_usage) {
+  for (let col in m_column_usage) {
     var height = 300 * m_column_usage[col] * inv_sum_col_usage;
     var tip = parseFloat(100 * m_column_usage[col] * inv_sum_col_usage).toFixed(2);
     var red = Math.floor(275 * m_column_usage[col] * inv_sum_col_usage) + 128
@@ -1717,11 +1719,11 @@ function generatePlots() {
   var y = 0;
   stats.append("text").attr("x", x + 40).attr("y", 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Row Usage")
   var sum_row_usage = 0;
-  for (var row in m_row_usage) {
+  for (let row in m_row_usage) {
     sum_row_usage += m_row_usage[row];
   }
   const inv_sum_row_usage = 1.0 / sum_row_usage;
-  for (var row in m_row_usage) {
+  for (let row in m_row_usage) {
     var height = 200 * m_row_usage[row] * inv_sum_row_usage;
     var tip = parseFloat(100 * m_row_usage[row] * inv_sum_row_usage).toFixed(2);
     var red = Math.floor(190 * m_row_usage[row] * inv_sum_row_usage) + 128
@@ -1744,7 +1746,7 @@ function generatePlots() {
   var sum = 0;
   var left = 0;
   var right = 0;
-  for (var finger in m_finger_usage) {
+  for (let finger in m_finger_usage) {
     sum += m_finger_usage[finger];
     if (finger <= 4) {
       left += m_finger_usage[finger];
@@ -1754,7 +1756,7 @@ function generatePlots() {
     }
   }
   var inv_sum = 1.0 / sum;
-  for (var finger in m_finger_usage) {
+  for (let finger in m_finger_usage) {
     var norm_finger_usage = m_finger_usage[finger] * inv_sum
     var height = 300 * norm_finger_usage;
     var tip = parseFloat(100 * norm_finger_usage).toFixed(2);
@@ -1779,7 +1781,7 @@ function generatePlots() {
   sum = 0
   left = 0;
   right = 0;
-  for (var finger in m_finger_distance) {
+  for (let finger in m_finger_distance) {
     sum += m_finger_distance[finger];
     if (finger <= 4) {
       left += m_finger_distance[finger];
@@ -1791,7 +1793,7 @@ function generatePlots() {
   var inv_max = 1.0 / max;
   inv_sum = 1.0 / sum;
   stats.append("text").attr("x", x + 40).attr("y", 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Finger Distance")
-  for (var finger in m_finger_distance) {
+  for (let finger in m_finger_distance) {
     if (m_finger_distance[finger] > 0) {
     var norm_finger_distance = m_finger_distance[finger] * inv_max;
     var height = 75 * norm_finger_distance;
@@ -1832,7 +1834,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     m_same_finger = Object.fromEntries(keyValueArray);
 
-    for (var bigram in m_same_finger) {
+    for (let bigram in m_same_finger) {
       sum += m_same_finger[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Finger Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -1840,7 +1842,7 @@ function generatePlots() {
 
     var i = 0;
     var t = scroll_amount;
-    for (var bigram in m_same_finger) {
+    for (let bigram in m_same_finger) {
       if (t > 0){
         t -= 1;
         continue;
@@ -1855,12 +1857,12 @@ function generatePlots() {
       if (i > 10) { break; }
     }
   } else if(sfb_toggle == 1){
-    for (var finger in m_same_finger2) {
+    for (let finger in m_same_finger2) {
       sum += m_same_finger2[finger] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial")
        .attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Finger Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
-    for (var finger in m_same_finger2) {
+    for (let finger in m_same_finger2) {
       var height = 30000 * m_same_finger2[finger] * inv_m_input_length;
       if (height > 150) { height = 150;}
       var tip = parseFloat(100 * m_same_finger2[finger] * inv_m_input_length).toFixed(2);
@@ -1883,7 +1885,7 @@ function generatePlots() {
     keyValueArray.sort((a, b) => b[1] - a[1]);
     m_same_finger3 = Object.fromEntries(keyValueArray);
 
-    for (var bigram in m_same_finger3) {
+    for (let bigram in m_same_finger3) {
       sum += m_same_finger3[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("2u Same Finger Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -1891,7 +1893,7 @@ function generatePlots() {
 
     var i = 0;
     var t = scroll_amount;
-    for (var bigram in m_same_finger3) {
+    for (let bigram in m_same_finger3) {
       if (t > 0){
         t -= 1;
         continue;
@@ -1916,7 +1918,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_skip_bigram);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var bigram in tmp) {
+    for (let bigram in tmp) {
       sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Skip Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -1924,7 +1926,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_skip_bigram2);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var bigram in tmp) {
+    for (let bigram in tmp) {
       sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Skip Bigrams (2u) " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -1939,7 +1941,7 @@ function generatePlots() {
   .on("mouseover", function() {      d3.select(this).attr("fill", "#bbbbbb");  })  .on("mouseout", function() {      d3.select(this).attr("fill", "#777777");  });
   var i = 0;
   var t = scroll_amount;
-  for (var bigram in tmp) {
+  for (let bigram in tmp) {
     if (t > 0){
       t -= 1;
       continue;
@@ -1962,7 +1964,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_lat_stretch);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var bigram in tmp) {
+    for (let bigram in tmp) {
       sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Lat Stretch Bigrams " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -1970,7 +1972,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_lat_stretch2);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var bigram in tmp) {
+    for (let bigram in tmp) {
       sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Ring LSBs " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -1985,7 +1987,7 @@ function generatePlots() {
   .on("mouseover", function() {      d3.select(this).attr("fill", "#bbbbbb");  })  .on("mouseout", function() {      d3.select(this).attr("fill", "#777777");  });
   var i = 0;
   var t = scroll_amount;
-  for (var bigram in tmp) {
+  for (let bigram in tmp) {
     if (t > 0){
       t -= 1;
       continue;
@@ -2009,7 +2011,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_pinky_scissors);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var bigram in tmp) {
+    for (let bigram in tmp) {
       sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Pinky/Ring Scissors " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -2017,7 +2019,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_scissors);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var bigram in tmp) {
+    for (let bigram in tmp) {
       sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Scissors " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -2025,7 +2027,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_all_scissors);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var bigram in tmp) {
+    for (let bigram in tmp) {
       sum += tmp[bigram] * inv_m_input_length;
     }
     stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Wide Scissors " + parseFloat(100 * sum).toFixed(2) + "%")
@@ -2039,7 +2041,7 @@ function generatePlots() {
   .on("mouseover", function() {      d3.select(this).attr("fill", "#bbbbbb");  })  .on("mouseout", function() {      d3.select(this).attr("fill", "#777777");  });
   var i = 0;
   var t = scroll_amount;
-  for (var bigram in tmp) {
+  for (let bigram in tmp) {
     if (t > 0){
       t -= 1;
       continue;
@@ -2066,7 +2068,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_trigram_count);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var cat in tmp) {
+    for (let cat in tmp) {
       sum += tmp[cat]
     }
     trigram_title = "Trigram Stats"
@@ -2076,7 +2078,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_trigram_count_alt);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var cat in tmp) {
+    for (let cat in tmp) {
       sum += tmp[cat]
     }
     trigram_title = "Trigram Stats (alts)"
@@ -2086,7 +2088,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_trigram_count_red);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var cat in tmp) {
+    for (let cat in tmp) {
       sum += tmp[cat]
     }
     trigram_title = "Trigram Stats (redirects)"
@@ -2096,7 +2098,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_trigram_count_roll_in);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var cat in tmp) {
+    for (let cat in tmp) {
       sum += tmp[cat]
     }
     trigram_title = "Trigram Stats (roll in)"
@@ -2106,7 +2108,7 @@ function generatePlots() {
     var keyValueArray = Object.entries(m_trigram_count_roll_out);
     keyValueArray.sort((a, b) => b[1] - a[1]);
     tmp = Object.fromEntries(keyValueArray);
-    for (var cat in tmp) {
+    for (let cat in tmp) {
       sum += tmp[cat]
     }
     trigram_title = "Trigram Stats (roll out)"
@@ -2146,7 +2148,7 @@ function generatePlots() {
   var i = 0
   var t = trigram_scroll_amount;
   inv_sum = 1.0 / sum;
-  for (var cat in tmp) {
+  for (let cat in tmp) {
     if (t > 0){
       t -= 1;
       continue;
@@ -2179,7 +2181,7 @@ function generatePlots() {
   stats.append("text").attr("x", x + 20).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Hand Strings")
   var i = 0
   t = sh_scroll_amount;
-  for (var word in samehandstrings) {
+  for (let word in samehandstrings) {
     if (t > 0){
       t -= 1;
       continue;
@@ -2210,7 +2212,7 @@ function generatePlots() {
   // console.log("scale       : "+scale)
   stats.append("text").attr("x", x + 20).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Same Hand Count")
   var i = 0
-  for (var len in samehandcount) {
+  for (let len in samehandcount) {
     var count = samehandcount[len];
     var width = scale * count;
     if (width > 100) {width = 100;}
@@ -2232,7 +2234,7 @@ function generatePlots() {
   stats.append("text").attr("x", x + 40).attr("y", y - 16).attr("font-size", 16).attr("font-family", "Sans,Arial").attr("fill", "#dfe2eb").attr("text-anchor", "left").text("Hard Words ")
   var i = 0
   t = hw_scroll_amount;
-  for (var word in word_effort) {
+  for (let word in word_effort) {
     word_len = word.length
     if (word_len > 3 && words[word] > 4){
       if (t > 0){


### PR DESCRIPTION
• Some lengths are computed once and reused.
• Maps are built to get indices and chars instantly.
• getEffort uses the default return of getCol and getRow (-1) to check for existence.
• exportLayout simplified.
• Math.pow() is expensive, prefer multiplications for small integer powers.